### PR TITLE
Fixed package name and added exact version for Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ into :
 ## 1 - Add to [Composer](http://composer.rarst.net/)
 
 - Add repository source : `{ "type": "vcs", "url": "https://github.com/BeAPI/composer-freeze-version" }`.
-- Include `"beapi/composer-freeze-version": "2.0.0"` into your composer.json file as require dev.
+- Include `"beapi/composer-freeze-version": "dev-master"` into your composer.json file as require dev.
 - Then `composer update` before use.
 
 ## 2 - Run command 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ into :
 ## 1 - Add to [Composer](http://composer.rarst.net/)
 
 - Add repository source : `{ "type": "vcs", "url": "https://github.com/BeAPI/composer-freeze-version" }`.
-- Include `"bea/composer/freeze-version": "dev-master"` into your composer.json file as require dev.
+- Include `"beapi/composer-freeze-version": "2.0.0"` into your composer.json file as require dev.
 - Then `composer update` before use.
 
 ## 2 - Run command 


### PR DESCRIPTION
This pull request fixes wrong package name in Readme.md installation section. Also, I found it a little bit ironic that package which main mission is to fix composer packages versions uses master branch as its own version constraint. I suppose it should fix itself version also or provide exact tag in installation instruction to avoid this situation.
